### PR TITLE
[Messenger] Messenger redis local sock dns

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -54,6 +54,17 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnOnUnixSocket()
+    {
+        $this->assertEquals(
+            new Connection(['stream' => 'messages'], [
+                'host' => '/var/run/redis/redis.sock',
+                'port' => 0,
+            ]),
+            Connection::fromDsn('redis:///var/run/redis/redis.sock')
+        );
+    }
+
     public function testFromDsnWithOptions()
     {
         $this->assertEquals(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Enable connection by unix socket to Redis.

``` messenger.yaml
framework:
    messenger:
        transports:
            async: "redis:///var/run/redis/redis.sock"
```

